### PR TITLE
[Fix] Add missing asPath for ServerPageContext

### DIFF
--- a/src/context-normalizers.ts
+++ b/src/context-normalizers.ts
@@ -108,6 +108,7 @@ export const ContextNormalizers = {
       params: context.params ?? {},
       query: removeParamsFromQuery(context.query, context.params ?? {}),
       pathname: buildPathname(context),
+      asPath: context.resolvedUrl,
     })
 
     return Object.defineProperties(base, {


### PR DESCRIPTION
ServerPageContext has `asPath` in types, but actually next.js doesn't provide it, instead we have `resolvedUrl` in `GetServerSidePropsContext` with the same value as `asPath`. So, for consistency, we need to add it with `asPath` field, because, for example when you try to switch your page from gip to gssp, you may encounter an inability to retrieve this value through the page event.