### PR TITLE
[Help wanted] Handle props to be optional in customize 

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -75,4 +75,6 @@ export interface AnyProps {
   [key: string]: any
 }
 
+export type NonPromise<T> = T extends Promise<infer U> ? never : T;
+
 export type GetInitialProps<P> = (context: NextPageContext) => Promise<P>


### PR DESCRIPTION
Make `props` to be optional in the `customize` field for GSSP / GSP

We need a type like
```ts
type GetStaticPropsPartialResult<Props> =
  GetStaticPropsResult<Props> extends { props: infer P } ?
    { props?: Partial<P>; revalidate?: number | boolean } & Omit<GetStaticPropsResult<Props>, 'props'> :
    GetStaticPropsResult<Props>;
```

But it is problematic to prepare from this type `GetServerSideProps` / `GetStaticProps` if we can use it in `CreateGSSPConfig` / `CreateGSPConfig`

Please, help with this type.
This is a draft refactor for internal checks only.